### PR TITLE
return fig.cap for fig.alt when fig.alt is null

### DIFF
--- a/R/utils-hook.R
+++ b/R/utils-hook.R
@@ -47,6 +47,7 @@ img_cap <- function(options, alt = FALSE) {
   }
   if (length(cap) == 0) cap <- ""
   if (is_blank(cap)) return(cap)
+  if (alt & is.null(options$fig.alt)) return(escape_html(options$fig.cap))
   if (alt) return(escape_html(options$fig.alt))
   paste0("<strong>", create_label(
     options$fig.lp, options$label,


### PR DESCRIPTION
Closes #58 

`fig.alt` defaults to `fig.cap` when `fig.alt` is not specified. This default behavior is consistent with `knitr` and `rmarkdown` default settings.