### PR TITLE
Fmt prop bug

### DIFF
--- a/R/formatting.R
+++ b/R/formatting.R
@@ -181,13 +181,15 @@ fmt_prop <- function(x, digits, fmt_small = TRUE, keep_zero = FALSE) {
     small_text <- small %>%
       fmt_digits(digits) %>%
       fmt_leading_zero() %>%
-      paste0_after(.first = "<")
+      only_if(is_latex_output())(paste0_after)(.first = "<") %>%
+      only_if(is_html_output())(paste0_after)(.first = "$\\lt$")
 
     large <- 1 - small
     large_text <- large %>%
       fmt_digits(digits) %>%
       fmt_leading_zero() %>%
-      paste0_after(.first = ">")
+      only_if(is_latex_output())(paste0_after)(.first = ">") %>%
+      only_if(is_html_output())(paste0_after)(.first = "$\\gt$")
 
     x_chr[x < small] <- small_text
     x_chr[x > large] <- large_text

--- a/R/formatting.R
+++ b/R/formatting.R
@@ -204,7 +204,7 @@ fmt_prop <- function(x, digits, fmt_small = TRUE, keep_zero = FALSE, output) {
 
 #' @export
 #' @rdname formatting
-fmt_prop_pct <- function(x, digits = 0, fmt_small = TRUE) {
+fmt_prop_pct <- function(x, digits = 0, fmt_small = TRUE, output) {
   x <- check_bound_real(x, name = "x", lb = 0, ub = 1)
   digits <- check_0_int(digits, name = "digits")
 
@@ -215,12 +215,14 @@ fmt_prop_pct <- function(x, digits = 0, fmt_small = TRUE) {
     small <- 1 / (10 ^ digits)
     small_text <- small %>%
       fmt_digits(digits) %>%
-      paste0_after(.first = "<")
+      only_if(output == "latex")(paste0_after)(.first = "<") %>%
+      only_if(output == "html")(paste0_after)(.first = "$\\lt$")
 
     large <- 100 - small
     large_text <- large %>%
       fmt_digits(digits) %>%
-      paste0_after(.first = ">")
+      only_if(output == "latex")(paste0_after)(.first = ">") %>%
+      only_if(output == "html")(paste0_after)(.first = "$\\gt$")
 
     x_chr[round(x * 100, digits = digits) < small] <- small_text
     x_chr[round(x * 100, digits = digits) > large] <- large_text

--- a/R/formatting.R
+++ b/R/formatting.R
@@ -168,7 +168,7 @@ fmt_corr <- function(x, digits, output = NULL) {
 
 #' @export
 #' @rdname formatting
-fmt_prop <- function(x, digits, fmt_small = TRUE, keep_zero = FALSE) {
+fmt_prop <- function(x, digits, fmt_small = TRUE, keep_zero = FALSE, output) {
   x <- check_bound_real(x, name = "x", lb = 0, ub = 1)
   digits <- check_pos_int(digits, name = "digits")
 
@@ -181,15 +181,15 @@ fmt_prop <- function(x, digits, fmt_small = TRUE, keep_zero = FALSE) {
     small_text <- small %>%
       fmt_digits(digits) %>%
       fmt_leading_zero() %>%
-      only_if(is_latex_output())(paste0_after)(.first = "<") %>%
-      only_if(is_html_output())(paste0_after)(.first = "$\\lt$")
+      only_if(output == "latex")(paste0_after)(.first = "<") %>%
+      only_if(output == "html")(paste0_after)(.first = "$\\lt$")
 
     large <- 1 - small
     large_text <- large %>%
       fmt_digits(digits) %>%
       fmt_leading_zero() %>%
-      only_if(is_latex_output())(paste0_after)(.first = ">") %>%
-      only_if(is_html_output())(paste0_after)(.first = "$\\gt$")
+      only_if(output == "latex")(paste0_after)(.first = ">") %>%
+      only_if(output == "html")(paste0_after)(.first = "$\\gt$")
 
     x_chr[x < small] <- small_text
     x_chr[x > large] <- large_text

--- a/R/table-format.R
+++ b/R/table-format.R
@@ -153,7 +153,7 @@ pad_prop <- function(x, digits, fmt_small = TRUE, keep_zero = FALSE,
   digits <- check_pos_int(digits)
   output <- check_output(output)
   new_x <- fmt_prop(x, digits = digits, fmt_small = fmt_small,
-                    keep_zero = keep_zero)
+                    keep_zero = keep_zero, output = output)
   new_x[is.na(new_x)] <- "NA"
 
   if(is_html_output()) {

--- a/R/table-format.R
+++ b/R/table-format.R
@@ -156,14 +156,28 @@ pad_prop <- function(x, digits, fmt_small = TRUE, keep_zero = FALSE,
                     keep_zero = keep_zero)
   new_x[is.na(new_x)] <- "NA"
 
-  if (any(stringr::str_detect(new_x, "^<|^>")) &
-      !all(stringr::str_detect(new_x, "^<|^>"))) {
-    pad <- ifelse(output == "latex", 4, 3)
-    new_x <- dplyr::case_when(stringr::str_detect(new_x, "^<|^>") ~
-                                paste0(new_x, paste(rep("\\ ", pad),
-                                                    collapse = "")),
-                              TRUE ~ new_x)
+  if(is_html_output()) {
+    if ((any(stringr::str_detect(new_x, "lt")) |
+         any(stringr::str_detect(new_x, "gt"))) &
+        !(all(stringr::str_detect(new_x, "lt") |
+              stringr::str_detect(new_x, "gt")))) {
+      pad <- ifelse(output == "latex", 4, 3)
+      new_x <- dplyr::case_when(stringr::str_detect(new_x, "^<|^>") ~
+                                  paste0(new_x, paste(rep("\\ ", pad),
+                                                      collapse = "")),
+                                TRUE ~ new_x)
+    }
+  } else if (is_latex_output()) {
+    if (any(stringr::str_detect(new_x, "^<|^>")) &
+        !all(stringr::str_detect(new_x, "^<|^>"))) {
+      pad <- ifelse(output == "latex", 4, 3)
+      new_x <- dplyr::case_when(stringr::str_detect(new_x, "^<|^>") ~
+                                  paste0(new_x, paste(rep("\\ ", pad),
+                                                      collapse = "")),
+                                TRUE ~ new_x)
+    }
   }
+
 
   if (any(x == 1, na.rm = TRUE)) {
     new_x <- dplyr::case_when(stringr::str_detect(new_x, "^1\\.") ~ new_x,

--- a/tests/testthat/test-formatting.R
+++ b/tests/testthat/test-formatting.R
@@ -42,17 +42,31 @@ test_that("fmt_prop_pct", {
   expect_match(err$message, "between 0 and 1")
 
   rand <- runif(5)
-  expect_equal(fmt_prop_pct(rand, fmt_small = FALSE),
+  expect_equal(fmt_prop_pct(rand, fmt_small = FALSE, output = "latex"),
                sprintf("%0.0f", rand * 100))
-  expect_equal(fmt_prop_pct(rand, digits = 2, fmt_small = FALSE),
+  expect_equal(fmt_prop_pct(rand, fmt_small = FALSE, output = "html"),
+               sprintf("%0.0f", rand * 100))
+  expect_equal(fmt_prop_pct(rand, digits = 2, fmt_small = FALSE,
+                            output = "latex"),
+               sprintf("%0.2f", rand * 100))
+  expect_equal(fmt_prop_pct(rand, digits = 2, fmt_small = FALSE,
+                            output = "html"),
                sprintf("%0.2f", rand * 100))
 
-  expect_equal(fmt_prop_pct(c(0.012, 0.009, 0.004, 0.989, 0.994, 0.997)),
+  expect_equal(fmt_prop_pct(c(0.012, 0.009, 0.004, 0.989, 0.994, 0.997),
+                            output = "latex"),
                c("1", "1", "<1", "99", "99", ">99"))
+  expect_equal(fmt_prop_pct(c(0.012, 0.009, 0.004, 0.989, 0.994, 0.997),
+                            output = "html"),
+               c("1", "1", "$\\lt$1", "99", "99", "$\\gt$99"))
   expect_equal(fmt_prop_pct(c(0.829, 0.080, NA_real_, 0.313, 0.002, 0.0004,
-                              0.998, 0.9999), digits = 1),
+                              0.998, 0.9999), digits = 1, output = "latex"),
                c("82.9", "8.0", NA_character_, "31.3", "0.2", "<0.1", "99.8",
                  ">99.9"))
+  expect_equal(fmt_prop_pct(c(0.829, 0.080, NA_real_, 0.313, 0.002, 0.0004,
+                              0.998, 0.9999), digits = 1, output = "html"),
+               c("82.9", "8.0", NA_character_, "31.3", "0.2", "$\\lt$0.1",
+                 "99.8", "$\\gt$99.9"))
 })
 
 test_that("fmt_leading_zero", {

--- a/tests/testthat/test-formatting.R
+++ b/tests/testthat/test-formatting.R
@@ -145,27 +145,52 @@ test_that("fmt_prop", {
   expect_match(err$message, "greater than zero")
 
   check1 <- test %>%
-    fmt_prop(digits = 3)
+    fmt_prop(digits = 3, output = "latex")
   expect_equal(check1, c(".853", ">.999", ".855",     NA,   ".690",
                          ".001",  ".129", ".869", ".169", "<.001"))
 
   check1_2 <- test %>%
-    fmt_prop(digits = 3, fmt_small = FALSE)
+    fmt_prop(digits = 3, fmt_small = FALSE, output = "latex")
   expect_equal(check1_2, c(".853", "1.000", ".855",     NA,   ".690",
                            ".001",  ".129", ".869", ".169", ".000"))
 
+  check1_3 <- test %>%
+    fmt_prop(digits = 3, output = "html")
+  expect_equal(check1_3, c(".853", "$\\gt$.999", ".855",     NA,   ".690",
+                           ".001",  ".129", ".869", ".169", "$\\lt$.001"))
+
+  check1_4 <- test %>%
+    fmt_prop(digits = 3, fmt_small = FALSE, output = "html")
+  expect_equal(check1_4, c(".853", "1.000", ".855",     NA,   ".690",
+                           ".001",  ".129", ".869", ".169", ".000"))
+
   check2 <- test %>%
-    fmt_prop(digits = 2)
+    fmt_prop(digits = 2, output = "latex")
   expect_equal(check2, c(".85",   ">.99", ".85",    NA,   ".69",
                          "<.01",  ".13", ".87", ".17", "<.01"))
 
   check2_2 <- test %>%
-    fmt_prop(digits = 2, fmt_small = FALSE)
+    fmt_prop(digits = 2, fmt_small = FALSE, output = "latex")
   expect_equal(check2_2, c(".85",   "1.00", ".85",    NA,   ".69",
                            ".00",  ".13", ".87", ".17", ".00"))
 
+  check2_3 <- test %>%
+    fmt_prop(digits = 2, output = "html")
+  expect_equal(check2_3, c(".85",   "$\\gt$.99", ".85",    NA,   ".69",
+                           "$\\lt$.01",  ".13", ".87", ".17", "$\\lt$.01"))
+
+  check2_4 <- test %>%
+    fmt_prop(digits = 2, fmt_small = FALSE, output = "html")
+  expect_equal(check2_4, c(".85",   "1.00", ".85",    NA,   ".69",
+                           ".00",  ".13", ".87", ".17", ".00"))
+
   check3 <- test %>%
-    fmt_prop(digits = 2, fmt_small = FALSE)
+    fmt_prop(digits = 2, fmt_small = FALSE, output = "latex")
+  expect_equal(check3, c(".85", "1.00", ".85",    NA, ".69",
+                         ".00",  ".13", ".87", ".17", ".00"))
+
+  check3_2 <- test %>%
+    fmt_prop(digits = 2, fmt_small = FALSE, output = "html")
   expect_equal(check3, c(".85", "1.00", ".85",    NA, ".69",
                          ".00",  ".13", ".87", ".17", ".00"))
 })


### PR DESCRIPTION
Closes #59 

Replaces the `<` symbol with `$\\lt$` and `>` with `$\\gt$` for the html versions of rendered tables.