### PR TITLE
Compatibility with ggplot2 4.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Imports:
     officedown (>= 0.2.2),
     purrr (>= 0.3.4),
     rlang (>= 0.3.4),
-    scales (>= 1.0.0),
+    scales (>= 1.4.0),
     stringr (>= 1.4.0),
     tibble (>= 2.1.3),
     tidyr (>= 0.8.3),

--- a/R/atlas-color-scales.R
+++ b/R/atlas-color-scales.R
@@ -69,12 +69,6 @@ scale_atlas <- function(aesthetics, use_black = FALSE, order = 1:6, darken = 0,
     values[ai] <- scales::alpha(values[ai], alpha[ai])
   }
 
-  pal <- function(n) {
-    if (n > length(values)) {
-      warning("Insufficient values in manual scale. ", n, " needed but only ",
-              length(values), " provided.", call. = FALSE)
-    }
-    values
-  }
+  pal <- scales::manual_pal(values, "colour")
   ggplot2::discrete_scale(aesthetics, palette = pal, ...)
 }

--- a/R/lcrost-color-scales.R
+++ b/R/lcrost-color-scales.R
@@ -70,12 +70,6 @@ scale_lcrost <- function(aesthetics, use_black = FALSE, order = 1:8,
     values[ai] <- scales::alpha(values[ai], alpha[ai])
   }
 
-  pal <- function(n) {
-    if (n > length(values)) {
-      warning("Insufficient values in manual scale. ", n, " needed but only ",
-              length(values), " provided.", call. = FALSE)
-    }
-    values
-  }
+  pal <- scales::manual_pal(values, "colour")
   ggplot2::discrete_scale(aesthetics, palette = pal, ...)
 }

--- a/R/okabeito-color-scales.R
+++ b/R/okabeito-color-scales.R
@@ -69,12 +69,6 @@ scale_okabeito <- function(aesthetics, use_black = FALSE, order = 1:8,
     values[ai] <- scales::alpha(values[ai], alpha[ai])
   }
 
-  pal <- function(n) {
-    if (n > length(values)) {
-      warning("Insufficient values in manual scale. ", n, " needed but only ",
-              length(values), " provided.", call. = FALSE)
-    }
-    values
-  }
+  pal <- scales::manual_pal(values, "colour")
   ggplot2::discrete_scale(aesthetics, palette = pal, ...)
 }

--- a/tests/testthat/_snaps/atlas-color-scales.md
+++ b/tests/testthat/_snaps/atlas-color-scales.md
@@ -1,0 +1,4 @@
+# atlas colors work
+
+    This manual palette can handle a maximum of 6 values. You have supplied 10
+

--- a/tests/testthat/_snaps/lcrost-color-scales.md
+++ b/tests/testthat/_snaps/lcrost-color-scales.md
@@ -1,0 +1,4 @@
+# Lisa Charlotte Rost colors work
+
+    This manual palette can handle a maximum of 8 values. You have supplied 10
+

--- a/tests/testthat/_snaps/okabeito-color-scales.md
+++ b/tests/testthat/_snaps/okabeito-color-scales.md
@@ -1,0 +1,4 @@
+# Okabe Ito colors work
+
+    This manual palette can handle a maximum of 8 values. You have supplied 10
+

--- a/tests/testthat/test-atlas-color-scales.R
+++ b/tests/testthat/test-atlas-color-scales.R
@@ -23,8 +23,7 @@ test_that("atlas colors work", {
     scale_color_atlas() +
     theme_atlas()
 
-  expect_warning(ggplot2::ggplot_build(plot3), "Insufficient values")
-  expect_warning(ggplot2::ggplot_build(plot3), "only 6 provided")
+  expect_snapshot_warning(ggplot2::ggplot_build(plot3))
   vdiffr::expect_doppelganger("atlas_color", plot)
   vdiffr::expect_doppelganger("atlas_fill",
                               plot2 + scale_fill_atlas(use_black = TRUE))

--- a/tests/testthat/test-lcrost-color-scales.R
+++ b/tests/testthat/test-lcrost-color-scales.R
@@ -23,8 +23,7 @@ test_that("Lisa Charlotte Rost colors work", {
     scale_color_lcrost() +
     theme_atlas()
 
-  expect_warning(ggplot2::ggplot_build(plot3), "Insufficient values")
-  expect_warning(ggplot2::ggplot_build(plot3), "only 8 provided")
+  expect_snapshot_warning(ggplot2::ggplot_build(plot3))
   vdiffr::expect_doppelganger("lcrost_color", plot)
   vdiffr::expect_doppelganger("lcrost_fill",
                               plot2 + scale_fill_lcrost(use_black = TRUE))

--- a/tests/testthat/test-okabeito-color-scales.R
+++ b/tests/testthat/test-okabeito-color-scales.R
@@ -23,8 +23,7 @@ test_that("Okabe Ito colors work", {
     scale_color_okabeito() +
     theme_atlas()
 
-  expect_warning(ggplot2::ggplot_build(plot3), "Insufficient values")
-  expect_warning(ggplot2::ggplot_build(plot3), "only 8 provided")
+  expect_snapshot_warning(ggplot2::ggplot_build(plot3))
   vdiffr::expect_doppelganger("okabeito_color", plot)
   vdiffr::expect_doppelganger("okabeito_fill",
                               plot2 + scale_fill_okabeito(use_black = TRUE))

--- a/tests/testthat/test-set-theme.R
+++ b/tests/testthat/test-set-theme.R
@@ -43,7 +43,7 @@ test_that("theme_atlas font colors are correct", {
   thm <- theme_get()
 
   expect_equal(thm$text$colour, "black")
-  expect_equal(thm$axis.text$colour, "grey30")
+  expect_in(thm$axis.text$colour, c("grey30", "#4D4D4DFF"))
 })
 
 test_that("theme_atlas grids, axis, and ticks are correct", {

--- a/tests/testthat/test-theme-atlas.R
+++ b/tests/testthat/test-theme-atlas.R
@@ -26,7 +26,7 @@ test_that("theme_atlas font sizes are correct", {
 
 test_that("theme_atlas font colors are correct", {
   expect_equal(thm$text$colour, "black")
-  expect_equal(thm$axis.text$colour, "grey30")
+  expect_in(thm$axis.text$colour, c("grey30", "#4D4D4DFF"))
 })
 
 test_that("theme_atlas grids, axis, and ticks are correct", {

--- a/tests/testthat/test-theme-atlas.R
+++ b/tests/testthat/test-theme-atlas.R
@@ -51,6 +51,7 @@ test_that("theme_atlas grids, axis, and ticks are correct", {
 })
 
 test_that("update_geom_font_defaults() works", {
+  skip_if(packageVersion("ggplot2") > "3.5.2")
   expect_equal(update_geom_font_defaults(),
                ggplot2::update_geom_defaults("text",
                                              list(family = "Arial Narrow",


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
One of the issues is that ggplot2 has become more picky about palettes that return too few values.
This PR fixes that issue and a few others.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time or let us know when ggplot2 should change. Hopefully this will inform you in a timely manner.

Best wishes,
Teun
